### PR TITLE
FIX: Update get_release_info.sh to address not getting latest version

### DIFF
--- a/get_release_info.sh
+++ b/get_release_info.sh
@@ -4,8 +4,8 @@ TMPDIR="$(mktemp -d)"
 
 curl -SsL https://api.github.com/repos/SoftFever/OrcaSlicer/releases/latest > $TMPDIR/latest.json
 
-url=$(jq -r '.assets[] | select(.browser_download_url|test("_Linux_ubuntu.zip$"))| .browser_download_url' $TMPDIR/latest.json)
-name=$(jq -r '.assets[] | select(.browser_download_url|test("_Linux_ubuntu.zip$"))| .name' $TMPDIR/latest.json)
+url=$(jq -r '.assets[] | select(.browser_download_url|test("_Linux*.zip$"))| .browser_download_url' $TMPDIR/latest.json)
+name=$(jq -r '.assets[] | select(.browser_download_url|test("_Linux*.zip$"))| .name' $TMPDIR/latest.json)
 version=$(jq -r .tag_name $TMPDIR/latest.json)
 
 if [ $# -ne 1 ]; then


### PR DESCRIPTION


Changed search pattern for the zip file so that it follows the new OrcaSlicer naming convention for releases.